### PR TITLE
Refine app general styling

### DIFF
--- a/app.html
+++ b/app.html
@@ -76,7 +76,8 @@
         <!-- Theme Modal -->
         <div id="themeModal" class="modal" style="display:none; z-index:2000;">
             <div class="modal-content" style="max-width:700px; width:95%; position:relative;">
-                <button onclick="closeThemeModal()" class="modal-close-btn" aria-label="Close">&times;</button>
+                <button onclick="closeThemeModal()" class="modal-close-btn" aria-label="Close"
+                    style="position:absolute; top:1rem; right:1rem; background:var(--bg-secondary); border:1px solid var(--border-color); font-size:1.5rem; color:var(--text-secondary); cursor:pointer; z-index:101; width:2.5rem; height:2.5rem; border-radius:50%; display:flex; align-items:center; justify-content:center;">&times;</button>
                 <h2 style="text-align:center;">Select a Theme</h2>
                 <div id="themeCardGrid" class="theme-card-grid"></div>
                 <button onclick="closeThemeModal()" style="margin-top:1rem; width:100%;">Close</button>

--- a/app.html
+++ b/app.html
@@ -76,8 +76,7 @@
         <!-- Theme Modal -->
         <div id="themeModal" class="modal" style="display:none; z-index:2000;">
             <div class="modal-content" style="max-width:700px; width:95%; position:relative;">
-                <button onclick="closeThemeModal()" class="modal-close-btn" aria-label="Close"
-                    style="position:absolute; top:1rem; right:1rem; background:none; border:none; font-size:2rem; color:var(--text-secondary); cursor:pointer; z-index:10;">&times;</button>
+                <button onclick="closeThemeModal()" class="modal-close-btn" aria-label="Close">&times;</button>
                 <h2 style="text-align:center;">Select a Theme</h2>
                 <div id="themeCardGrid" class="theme-card-grid"></div>
                 <button onclick="closeThemeModal()" style="margin-top:1rem; width:100%;">Close</button>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2143,7 +2143,9 @@ h6 {
 
 /* Ultra Colorful Theme Special Effects */
 body[data-theme="ultracolourful"] {
-    background: #ff6b6b;
+    background: linear-gradient(45deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4, #ffeaa7, #dda0dd);
+    background-size: 400% 400%;
+    animation: gradientShift 10s ease infinite;
 }
 
 @keyframes gradientShift {


### PR DESCRIPTION
Fix theme modal close button overlap and functionality.

The close button in the theme changer modal was overlapping with the title text and was not clickable due to conflicting inline styles in `app.html` overriding the CSS positioning and `z-index`.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-1731faad-f2a0-49df-ad46-e5a7c1b2402f) · [Cursor](https://cursor.com/background-agent?bcId=bc-1731faad-f2a0-49df-ad46-e5a7c1b2402f)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)